### PR TITLE
Fixing Usage to actually trigger popups 

### DIFF
--- a/proposals/Storage-Access-API/storage-access-api-demo/SharedId/sandbox.js
+++ b/proposals/Storage-Access-API/storage-access-api-demo/SharedId/sandbox.js
@@ -21,34 +21,31 @@ function storageAccessAPISupported() {
   );
 }
 
-function accessStorage(fn) {
+function requestAccess(fn) {
+  document.requestStorageAccess()
+    .then(function () {
+      console.info('Storage API Access granted.');
+      fn();
+      return;
+      }, function (){
+      console.warn('Storage API Access denied.');
+      });
+  }
+
+function hasAccess() {
   document.hasStorageAccess()
-    .then(function (hasAccess){
+    .then(hasAccess =>{
       if (hasAccess) {
-        console.info('Storage API Access already granted');
-        fn();
-        return;
+        console.info('Frame has Storage Access');
+      } else {
+        console.info('Frame does not have Storage Access');
       }
-
-      console.info('no existing Storage API Access ...');
-      console.info('requesting Storage API Access ...');
-
-      document.requestStorageAccess()
-        .then(function () {
-          console.info('Storage API Access granted.');
-          fn();
-          return;
-        }, function (){
-          console.warn('Storage API Access denied.');
-        });
-    }, function (reason) {
-      console.warn('something went wrong ...');
-      console.error(reason);
     });
-}
+  }
 
 function onUpdated(event) {
   renderUid(event.detail.sharedId);
+  console.info('OnUpdate Called');
 }
 
 function updateId() {
@@ -86,7 +83,7 @@ function init() {
 
 function attachEventHandlers() {
   sharedId.addEventListener('sharedId:updated', onUpdated);
-  btn.addEventListener('click', accessStorage.bind(null, updateId));
+  btn.addEventListener('click', requestAccess.bind(null, updateId));
 }
 
 function onReady() {
@@ -95,7 +92,8 @@ function onReady() {
     btn.classList.add('pure-button-disabled');
     btn.innerText = 'Storage Access API not supported';
     return;
-  }
+  } 
+  hasAccess();
   attachEventHandlers();
   init();
 }


### PR DESCRIPTION
Fixed according to https://webkit.org/blog/11545/updates-to-the-storage-access-api/ - hasStorageAccess and requestStorageAccess cannot be called during the same user gesture. This was the case in the current implementation, which thus never triggered a permission prompt (and also never enabled access in Safari with 3rd party blocking enabled)

Safari and FireFox now properly show interceptions and enable iFrame Storage Access with 3rd Party Blocking enabled (Safari) and Strict ETP with Storage Partitioning (FF). Both Browsers behave largely different though.

- No write access from 3rd Party iFrame in Safari (possible with FF)
- Reload resets Storage Access in Safari (keeps the permission though), which is not the case for FF (retains access as well as the permission)
